### PR TITLE
Use jnr-posix instead of jna-posix

### DIFF
--- a/src/main/java/hudson/security/PAMSecurityRealm.java
+++ b/src/main/java/hudson/security/PAMSecurityRealm.java
@@ -37,10 +37,10 @@ import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.userdetails.User;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
-import org.jruby.ext.posix.FileStat;
-import org.jruby.ext.posix.Group;
-import org.jruby.ext.posix.POSIX;
-import org.jruby.ext.posix.Passwd;
+import jnr.posix.FileStat;
+import jnr.posix.Group;
+import jnr.posix.POSIX;
+import jnr.posix.Passwd;
 import org.jvnet.libpam.PAM;
 import org.jvnet.libpam.PAMException;
 import org.jvnet.libpam.UnixUser;
@@ -158,7 +158,7 @@ public class PAMSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             if(s.exists() && !s.canRead()) {
                 // it looks like shadow password is in use, but we don't have read access
                 LOGGER.fine("/etc/shadow exists but not readable");
-                POSIX api = PosixAPI.get();
+                POSIX api = PosixAPI.jnr();
                 FileStat st = api.stat("/etc/shadow");
                 if(st==null)
                     return FormValidation.error(Messages.PAMSecurityRealm_ReadPermission());


### PR DESCRIPTION
I think that pam-auth-plugin should follow an example of jenkins-core and migrate to jnr-posix.

Edit: "auth-plugin" -> "pam-auth-plugin"
