### PR TITLE
[JENKINS-35285] Upgrade to parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.566</version>
+    <version>2.9</version>
   </parent>
 
   <artifactId>pam-auth</artifactId>
@@ -24,8 +24,7 @@
   </licenses>
   
   <properties>
-    <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
-    <findbugs.failOnError>true</findbugs.failOnError>
+    <jenkins.version>1.566</jenkins.version>
   </properties>
 
   <scm>
@@ -53,44 +52,6 @@
       <artifactId>libpam4j</artifactId>
       <version>1.6</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <!-- details defined in the parent POM -->
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${findbugs-maven-plugin.version}</version>
-        <configuration>
-          <failOnError>${findbugs.failOnError}</failOnError>
-          <xmlOutput>true</xmlOutput>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-findbugs</id>
-            <phase>verify</phase> 
-            <goals>
-              <goal>check</goal> 
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
   
   <properties>
     <jenkins.version>1.566</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <scm>


### PR DESCRIPTION
Updated dependencies for maven-release, findbugs, and annotations.  Kept jenkins.version at 1.566.  Passed tests on that and 2.6.  Implements [JENKINS-35285](https://issues.jenkins-ci.org/browse/JENKINS-35285)

@reviewbybees 