### PR TITLE
Java 11 readiness: use recommended build configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,1 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())


### PR DESCRIPTION
Tested locally, and seems this plugin is actually already building fine on all variants. So I thought enabling this continuous check would be good.

@jenkinsci/java11-support FYI