### PR TITLE
Add JCasC integration test

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+_extends: .github
+tag-template: pam-auth-$NEXT_MINOR_VERSION

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
       <artifactId>libpam4j</artifactId>
       <version>1.11</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <!-- versions past 1.36 require newer versions of Jenkins (~2.222) as a baseline -->
+      <version>1.36</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>4.3</version>
   </parent>
 
   <artifactId>pam-auth</artifactId>
@@ -26,7 +26,7 @@
   <properties>
     <revision>1.6.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <revision>1.6.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.164.3</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -58,8 +58,7 @@
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <!-- versions past 1.36 require newer versions of Jenkins (~2.222) as a baseline -->
-      <version>1.36</version>
+      <version>1.41</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/hudson/security/PAMSecurityRealmJCasCTest.java
+++ b/src/test/java/hudson/security/PAMSecurityRealmJCasCTest.java
@@ -1,0 +1,25 @@
+package hudson.security;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class PAMSecurityRealmJCasCTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("config.yaml")
+    public void testConfigYaml() {
+        SecurityRealm securityRealm = j.jenkins.getSecurityRealm();
+        assertThat(securityRealm, instanceOf(PAMSecurityRealm.class));
+        PAMSecurityRealm pam = (PAMSecurityRealm) securityRealm;
+        assertThat(pam.serviceName, equalTo("sudo"));
+    }
+}

--- a/src/test/resources/config.yaml
+++ b/src/test/resources/config.yaml
@@ -1,0 +1,4 @@
+jenkins:
+  securityRealm:
+    pam:
+      serviceName: sudo


### PR DESCRIPTION
This is a fairly simple plugin configuration-wise as it simply chooses which PAM service to use for authenticating users. The default is `sshd` which sort of makes sense without a specific `/etc/pam.d/jenkins` config file.