### PR TITLE
Remove jnr-posix dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,6 @@
       <version>1.11</version>
     </dependency>
     <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>jnr-posix-api</artifactId>
-      <version>3.1.7-1</version>
-    </dependency>
-    <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
       <scope>test</scope>

--- a/src/main/java/hudson/security/PAMSecurityRealm.java
+++ b/src/main/java/hudson/security/PAMSecurityRealm.java
@@ -122,6 +122,8 @@ public class PAMSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             FileSystems.getDefault().getUserPrincipalLookupService().lookupPrincipalByGroupName(groupName);
         } catch (IOException e) {
             throw new UsernameNotFoundException(group);
+        } catch (UnsupportedOperationException e) {
+            throw new UsernameNotFoundException("Unable to generate the lookup service to load " + group);
         }
         return new GroupDetails() {
             @Override
@@ -186,6 +188,8 @@ public class PAMSecurityRealm extends AbstractPasswordBasedSecurityRealm {
                     shadowGroup = fileAttributes.group().getName();
                 } catch (IOException e) {
                     return FormValidation.error(Messages.PAMSecurityRealm_ReadPermission());
+                } catch (UnsupportedOperationException e) {
+                    return FormValidation.error(Messages.PAMSecurityRealm_UnsupportedOperation());
                 }
                 String user = System.getProperty("user.name") != null ? Messages.PAMSecurityRealm_User(System.getProperty("user.name")) : Messages.PAMSecurityRealm_CurrentUser();
 

--- a/src/main/resources/hudson/security/pam/Messages.properties
+++ b/src/main/resources/hudson/security/pam/Messages.properties
@@ -7,3 +7,4 @@ PAMSecurityRealm.Success=Success
 PAMSecurityRealm.User=User \u2018{0}\u2019
 PAMSecurityRealm.CurrentUser=Current User
 PAMSecurityRealm.Uid=uid: {0}
+PAMSecurityRealm.UnsupportedOperation=It is not possible to retrieve the file attributes for `/etc/shadow` file and so it is impossible to test the configuration 

--- a/src/test/java/hudson/security/PAMSecurityRealmTest.java
+++ b/src/test/java/hudson/security/PAMSecurityRealmTest.java
@@ -4,9 +4,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 import hudson.Functions;
-import hudson.os.PosixAPI;
 import hudson.security.SecurityRealm.SecurityComponents;
-import jnr.posix.POSIX;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,8 +33,8 @@ public class PAMSecurityRealmTest {
             // expected
         }
 
-        POSIX api = PosixAPI.jnr();
-        String name = api.getpwuid(api.geteuid()).getLoginName();
+
+        String name = System.getProperty("user.name");
         System.out.println(Arrays.asList(sc.userDetails.loadUserByUsername(name).getAuthorities()));
     }
 }


### PR DESCRIPTION
This plugin was using the `jnr-posix` library to get information about the owner of the `/etc/shadow` file in the host in order to give meaningful error messages in the configuration screen.

That information can now be retrieved using standard java libraries, so there is no need for a specialized library.

Apart from the unit tests I have manually tested using `mvn hpi:run` 

* In my system I tested that the `test` button in the security configuration gave me a expected error message when the user used to run jenkins did not had access to the `/etc/shadow` file
* I added the user to the  `shadow` group so it is able to read the `/etc/shadow` file and then checked that the `test` button was working correctly
* With the user still being a part of the `shadow` group I configured the security realm provided by this plugin and checked that I was able to log using the host os user and password as expected    

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
