### PR TITLE
Update plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
   <packaging>hpi</packaging>
 
   <name>PAM Authentication plugin</name>
-  <description>Adds Unix Pluggable Authentication Module (PAM) support to Jenkins</description>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.46</version>
     <relativePath />
   </parent>
 
@@ -28,12 +28,11 @@
     <revision>1.9</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.303.3</jenkins.version>
-    <java.level>8</java.level>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Adds Unix Pluggable Authentication Module (PAM) support to Jenkins
+</div>


### PR DESCRIPTION
The old plugin parent POM pulls in an older HtmlUnit library which inhibits compatibility testing with recent versions of Jenkins core. By updating the plugin parent POM we also get a new HtmlUnit library which assists in compatibility testing.